### PR TITLE
Fix redirect link of 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Refresh" content="5;url="https://peanutssbot.tk">
+<meta http-equiv="Refresh" content="5;url=https://peanutssbot.tk">
 <link rel="icon" href="images/logo_peanut_tron.png">
     <title>Peanutss - The Discord Bot</title>
 </head>


### PR DESCRIPTION
Fix the redirect link of 404 page because the quotation mark in the refresh content made the website does not understand the request and needs to remove it to make the website understand and redirects to home page.